### PR TITLE
Fix body parsing termination and parser finalization

### DIFF
--- a/src/http/parser/HttpParser.cpp
+++ b/src/http/parser/HttpParser.cpp
@@ -37,8 +37,9 @@ void HttpParser::parse() {
 		// DoneState의 handleNextState는 상태 변경 안 함
 		// State 클래스 내부에서 DoneState로 전환된 후, DoneState를 검사
 	}
-	// 파싱 종료 후 DoneState에서도 한 번 호출돼 결과 설정
-	_currentState->parse(this, std::string());
+        // 파싱 종료 후 DoneState에서도 한 번 호출돼 결과 설정
+        _currentState->parse(this, std::string());
+        _currentState->handleNextState(this);
 }
 
 // 파싱 결과 반환: HttpPacket 복사

--- a/src/http/parser/state/BodyState.cpp
+++ b/src/http/parser/state/BodyState.cpp
@@ -2,13 +2,16 @@
 #include "BodyState.hpp"
 
 void BodyState::parse(HttpParser* parser, const std::string& line) {
-	if (_remain == 0) _done = true;
-	if (_done) return;
-	// 남은 본문 길이만큼 복사
-	size_t toCopy = std::min(_remain, line.size());
-	// HttpPacket에 본문 데이터 추가
-	parser->_packet->appendBody(line.data(), toCopy);
-	_remain -= toCopy;
+        if (_remain == 0) {
+                _done = true;
+                return;
+        }
+        // 남은 본문 길이만큼 복사
+        size_t toCopy = std::min(_remain, line.size());
+        // HttpPacket에 본문 데이터 추가
+        parser->_packet->appendBody(line.data(), toCopy);
+        _remain -= toCopy;
+        if (_remain == 0) _done = true;
 }
 
 void BodyState::handleNextState(HttpParser* parser) {

--- a/src/http/parser/state/BodyState.hpp
+++ b/src/http/parser/state/BodyState.hpp
@@ -3,6 +3,7 @@
 #define BODYSTATE_HPP
 
 #include <string>
+#include <algorithm>
 
 #include "ParseState.hpp"
 


### PR DESCRIPTION
## Summary
- include `<algorithm>` in BodyState
- ensure BodyState marks done as soon as all bytes are read
- finalize parser state after the last parse call

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6884f3af885c832995288ff123f4872c