### PR TITLE
Improve body parsing in HTTP parser

### DIFF
--- a/src/http/parser/HttpParser.cpp
+++ b/src/http/parser/HttpParser.cpp
@@ -19,27 +19,41 @@ void HttpParser::changeState(ParseState* newState) {
 }
 
 // 파싱 실행: 줄 단위로 읽어 각 State에 전달
+
 void HttpParser::parse() {
-	std::istringstream stream(_rawData);
-	std::string		   line;
+        std::istringstream stream(_rawData);
+        std::string        line;
 
-	// CRLF 분리를 위해 getline 사용 ('' 제거)
-	while (std::getline(stream, line)) {
-		// Remove trailing '\r'
-		if (!line.empty() && line.back() == '\r') {
-			line.pop_back();
-		}
-		// 현재 상태에 파싱 위임
-		_currentState->parse(this, line);
-		_currentState->handleNextState(this);
+        // 패킷 라인과 헤더를 우선 파싱한다.
+        while (std::getline(stream, line)) {
+                if (!line.empty() && line.back() == '\r') line.pop_back();
 
-		// Done 상태 도달 시 중지
-		// DoneState의 handleNextState는 상태 변경 안 함
-		// State 클래스 내부에서 DoneState로 전환된 후, DoneState를 검사
-	}
-	// 파싱 종료 후 DoneState에서도 한 번 호출돼 결과 설정
-	_currentState->parse(this, std::string());
+                _currentState->parse(this, line);
+                _currentState->handleNextState(this);
+
+                // BodyState 또는 DoneState로 전환되면 본문 처리로 넘어간다.
+                if (dynamic_cast<BodyState*>(_currentState) ||
+                        dynamic_cast<DoneState*>(_currentState))
+                        break;
+        }
+
+        // BodyState일 경우 Content-Length 만큼 그대로 읽어 전달
+        BodyState* bodyState = dynamic_cast<BodyState*>(_currentState);
+        if (bodyState) {
+                size_t      contentLength = 0;
+                std::string lengthStr     = _packet->getHeader().get("Content-Length");
+                if (!lengthStr.empty()) contentLength = std::stoi(lengthStr);
+
+                std::string body(contentLength, '\0');
+                stream.read(&body[0], contentLength);
+                body.resize(stream.gcount());
+
+                bodyState->parse(this, body);
+                bodyState->handleNextState(this);
+        }
+
+        // 파싱 종료 후 DoneState에서도 한 번 호출돼 결과 설정
+        _currentState->parse(this, std::string());
 }
-
 // 파싱 결과 반환: HttpPacket 복사
 HttpPacket HttpParser::getResult() { return *_packet; }


### PR DESCRIPTION
## Summary
- read packet body without getline in `HttpParser::parse`
- respect `Content-Length` and feed raw bytes to `BodyState`

## Testing
- `g++ -std=c++11 ... -fsyntax-only` *(fails: expected class-name before '{' token)*

------
https://chatgpt.com/codex/tasks/task_e_6884f487b1d083298190c5f3f75a434c